### PR TITLE
単一プロセスでの実行を延長したらGC.startを実行しない

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,9 @@ Security/Eval:
 
 Lint/MissingSuper:
   Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ blue's data['count'] is 9
 ### 単一プロセスでの実行を延長する
 * workerクラスの中で、`BlueGreenProcess::SharedVariable.extend_run_on_this_process`にtrueをセットするともう一度同じプロセスで処理を行います
     * 次の実行でtrueを明示しない限りはプロセスを切り替えます
+* 単一プロセスでの実行を延長するとGC.startを実行しなくなります
+    * 長時間にわたって延長する時は手動でGC.startを実行してください
 
 ```ruby
 BlueGreenProcess.configure do |config|

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ blue's data['count'] is 9
 * workerクラスの中で、`BlueGreenProcess::SharedVariable.extend_run_on_this_process`にtrueをセットするともう一度同じプロセスで処理を行います
     * 次の実行でtrueを明示しない限りはプロセスを切り替えます
 * 単一プロセスでの実行を延長するとGC.startを実行しなくなります
-    * 長時間にわたって延長する時は手動でGC.startを実行してください
+    * 長時間にわたって延長する時は呼び出し側でGC.startを実行してください
 
 ```ruby
 BlueGreenProcess.configure do |config|

--- a/lib/blue_green_process.rb
+++ b/lib/blue_green_process.rb
@@ -18,8 +18,8 @@ module BlueGreenProcess
 
   PROCESS_COMMAND_DIE = "die"
   PROCESS_COMMAND_BE_ACTIVE = "be_active"
-  PROCESS_COMMAND_BE_INACTIVE = "work"
-  PROCESS_COMMAND_WORK = "be_inactive"
+  PROCESS_COMMAND_BE_INACTIVE = "be_inactive"
+  PROCESS_COMMAND_WORK = "work"
 
   RESPONSE_OK = "OK"
   RESPONSE_ERROR = "ERR"

--- a/lib/blue_green_process/master_process.rb
+++ b/lib/blue_green_process/master_process.rb
@@ -58,7 +58,7 @@ module BlueGreenProcess
             BlueGreenProcess.logger.debug "[BLUE_GREEN_PROCESS] #{label} has become inactive(#{$PROCESS_ID})"
             child_write.puts({ c: BlueGreenProcess::RESPONSE_OK,
                                data: BlueGreenProcess::SharedVariable.data }.to_json)
-            ::GC.start
+            ::GC.start unless BlueGreenProcess::SharedVariable.extend_run_on_this_process
           when BlueGreenProcess::PROCESS_COMMAND_WORK
             if process_status == BlueGreenProcess::PROCESS_STATUS_INACTIVE
               warn "Should not be able to run in this status"

--- a/spec/integration/extend_run_on_single_process_spec.rb
+++ b/spec/integration/extend_run_on_single_process_spec.rb
@@ -4,35 +4,68 @@ RSpec.describe "BlueGreenProcess integration extend run on single_process" do
   let(:worker_instance) { worker_class.new }
 
   context "when extend_run_on_this_process が常にtrueのとき" do
-    let(:worker_class) do
-      Class.new(BlueGreenProcess::BaseWorker) do
-        def work(label)
-          BlueGreenProcess::SharedVariable.data["count"] += 1
-          BlueGreenProcess::SharedVariable.extend_run_on_this_process = true
-          BlueGreenProcess::SharedVariable.data["count_display"] =
-            "#{label}:#{BlueGreenProcess::SharedVariable.data["count"]}"
+    describe "GC.startを実行しない" do
+      let(:worker_class) do
+        Class.new(BlueGreenProcess::BaseWorker) do
+          def work(_label)
+            BlueGreenProcess::SharedVariable.data["gc_count"] = GC.count
+            BlueGreenProcess::SharedVariable.extend_run_on_this_process = true
+          end
         end
       end
-    end
 
-    before do
-      BlueGreenProcess.configure do |config|
-        config.shared_variables = %i[count count_display]
+      before do
+        BlueGreenProcess.configure do |config|
+          config.shared_variables = %i[gc_count]
+        end
+      end
+
+      it "gc countが増えないこと" do
+        process = BlueGreenProcess.new(worker_instance: worker_instance, max_work: 3)
+        expect(BlueGreenProcess::SharedVariable.data["gc_count"]).to be_nil
+        process.work
+        expect { process.work }.not_to change { BlueGreenProcess::SharedVariable.data["gc_count"] }
+        expect { process.work }.not_to change { BlueGreenProcess::SharedVariable.data["gc_count"] }
+        expect { process.work }.not_to change { BlueGreenProcess::SharedVariable.data["gc_count"] }
+      ensure
+        process&.shutdown
       end
     end
 
-    it do
-      BlueGreenProcess::SharedVariable.data["count"] = 0
-      process = BlueGreenProcess.new(worker_instance: worker_instance, max_work: 3)
-      expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq(nil)
-      process.work # blue
-      expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq("blue:3")
-      process.work # blue
-      expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq("blue:6")
-      process.work # blue
-      expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq("blue:9")
-    ensure
-      process&.shutdown
+    describe "値の共有" do
+      let(:worker_class) do
+        Class.new(BlueGreenProcess::BaseWorker) do
+          def work(label)
+            BlueGreenProcess::SharedVariable.data["count"] += 1
+            BlueGreenProcess::SharedVariable.extend_run_on_this_process = true
+            BlueGreenProcess::SharedVariable.data["count_display"] =
+              "#{label}:#{BlueGreenProcess::SharedVariable.data["count"]}"
+          end
+        end
+      end
+
+      before do
+        BlueGreenProcess.configure do |config|
+          config.shared_variables = %i[count count_display]
+        end
+      end
+
+      it do
+      end
+
+      it do
+        BlueGreenProcess::SharedVariable.data["count"] = 0
+        process = BlueGreenProcess.new(worker_instance: worker_instance, max_work: 3)
+        expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq(nil)
+        process.work # blue
+        expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq("blue:3")
+        process.work # blue
+        expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq("blue:6")
+        process.work # blue
+        expect(BlueGreenProcess::SharedVariable.data["count_display"]).to eq("blue:9")
+      ensure
+        process&.shutdown
+      end
     end
   end
 

--- a/spec/integration/gc_spec.rb
+++ b/spec/integration/gc_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe "BlueGreenProcess integration gc start" do
+  let(:worker_instance) { worker_class.new }
+
+  describe "workをするごとにGC.startを実行する" do
+    let(:worker_class) do
+      Class.new(BlueGreenProcess::BaseWorker) do
+        def work(_label)
+          BlueGreenProcess::SharedVariable.data["gc_count"] += GC.count
+        end
+      end
+    end
+
+    before do
+      BlueGreenProcess.configure do |config|
+        config.shared_variables = %i[gc_count]
+      end
+    end
+
+    it "gc countが増えること" do
+      BlueGreenProcess::SharedVariable.data["gc_count"] = 0
+      process = BlueGreenProcess.new(worker_instance: worker_instance, max_work: 3)
+      process.work
+      expect { process.work }.to change { BlueGreenProcess::SharedVariable.data["gc_count"] }
+      process.work
+      expect { process.work }.to change { BlueGreenProcess::SharedVariable.data["gc_count"] }
+      process.work
+      expect { process.work }.to change { BlueGreenProcess::SharedVariable.data["gc_count"] }
+    ensure
+      process&.shutdown
+    end
+  end
+end


### PR DESCRIPTION
共有オブジェクトを読み書きする都合上、一度be_inactive経由でGC.startを実行してしまっていて、workの実行開始が遅延していた。

延長したら単一プロセスでのGC.startは走らせない。延長した側でハンドリングするべき。