### PR TITLE
処理を停止するときにpidを書いたファイルも削除する

### DIFF
--- a/lib/blue_green_process.rb
+++ b/lib/blue_green_process.rb
@@ -63,7 +63,7 @@ module BlueGreenProcess
     begin
       worker_pids = File.read(PID_PATH).split(",").map(&:to_i)
     rescue Errno::ENOENT
-      warn("#{PID_PATH}にファイルがありませんでした")
+      BlueGreenProcess.logger.warn("[BLUE_GREEN_PROCESS] #{PID_PATH}にファイルがありませんでした")
       return
     end
 
@@ -72,12 +72,8 @@ module BlueGreenProcess
     rescue Errno::ESRCH => e
       BlueGreenProcess.logger.warn("[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] workerプロセス(#{worker_pid})の終了に失敗しました。#{e.message}")
     end
-
-    begin
-      Process.wait
-    rescue Errno::ECHILD => e
-      BlueGreenProcess.logger.warn("[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] Process.wait(#{e.message})に失敗しました")
-    end
-    BlueGreenProcess.logger.warn "[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] TERMシグナルを送信しました"
+    BlueGreenProcess.logger.warn "[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] workerプロセスへTERMシグナルを送信しました"
+    Process.waitall
+    BlueGreenProcess.logger.warn "[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] workerプロセスが終了しました"
   end
 end

--- a/lib/blue_green_process.rb
+++ b/lib/blue_green_process.rb
@@ -75,5 +75,7 @@ module BlueGreenProcess
     BlueGreenProcess.logger.warn "[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] workerプロセスへTERMシグナルを送信しました"
     Process.waitall
     BlueGreenProcess.logger.warn "[BLUE_GREEN_PROCESS][#{$PROCESS_ID}] workerプロセスが終了しました"
+  ensure
+    FileUtils.rm_rf(BlueGreenProcess::PID_PATH)
   end
 end

--- a/lib/blue_green_process/master_process.rb
+++ b/lib/blue_green_process/master_process.rb
@@ -115,6 +115,9 @@ module BlueGreenProcess
     def shutdown
       @processes.each(&:shutdown)
       Process.waitall
+    ensure
+      # 正常終了だとworkerから削除するケースはないんだけど、想定外のエラーが起きた時を考慮してworkerから削除する
+      FileUtils.rm_rf(BlueGreenProcess::PID_PATH)
     end
 
     private

--- a/spec/blue_green_process_spec.rb
+++ b/spec/blue_green_process_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe BlueGreenProcess do
       end
     end
 
-    it 'workerプロセスを終了すること' do
+    it "workerプロセスを終了すること" do
       process = BlueGreenProcess.new(worker_instance: worker_instance, max_work: 3)
       process.work
       BlueGreenProcess.terminate_workers_immediately

--- a/spec/blue_green_process_spec.rb
+++ b/spec/blue_green_process_spec.rb
@@ -43,4 +43,23 @@ RSpec.describe BlueGreenProcess do
       described_class.config.after_fork.call
     end
   end
+
+  describe ".terminate_workers_immediately" do
+    let(:worker_instance) { worker_class.new }
+    let(:worker_class) do
+      Class.new(BlueGreenProcess::BaseWorker) do
+        def work(label)
+          puts "work #{label}"
+        end
+      end
+    end
+
+    it 'workerプロセスを終了すること' do
+      process = BlueGreenProcess.new(worker_instance: worker_instance, max_work: 3)
+      process.work
+      BlueGreenProcess.terminate_workers_immediately
+      expect(Process.waitall).to eq([])
+      expect(File.exist?(BlueGreenProcess::PID_PATH)).to eq(false)
+    end
+  end
 end

--- a/spec/integration/after_fork_spec.rb
+++ b/spec/integration/after_fork_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe "BlueGreenProcess integration after_fork" do
            "green" * 2,
            "blue"  * 2].join
         )
+        expect(File.exist?(BlueGreenProcess::PID_PATH)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
今までそれが残ってしまっていた。

通常のユースケースでは問題がないんだけど、実行ユーザを変えるときに権限エラーが起きがち。そもそもプロセスを停止したら一時ファイルは残すべきではないのでしっかり削除する。
https://github.com/splaplapla/procon_bypass_man/issues/282